### PR TITLE
Remove sort

### DIFF
--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -44,12 +44,6 @@ m_grid_size({j["__cWid"].get<int>(), j["__cHei"].get<int>()})
         m_tiles.push_back(new_tile);
     }
 
-    std::sort(
-        m_tiles.begin(),
-        m_tiles.end(),
-        [](const Tile& lhs, const Tile& rhs) {return lhs.coordId < rhs.coordId;}
-    );
-
     for (auto& tile : m_tiles)
         m_tiles_map[tile.coordId] = &tile;
 


### PR DESCRIPTION
I'm noticing that when I do an auto layer and then render all the tiles in the order they are returned in the allTiles method of Layer, I will get a mixture of the different tiles specified in the auto layer.

![image](https://user-images.githubusercontent.com/242570/124526066-90aa9800-ddcf-11eb-8c5b-232af1d4e635.png)

This is from the Entities.ldtk example file provided with the software.

The reason this looks chewed up and patchy is because with the normal tiles you would see, there's also other tiles created by other rules. The sort function here mixes all the tiles together and if they're rendered in the order received, it's all mixed up.
There doesn't seem to be any way to distinguish between what is meant to be shown and what should not be shown, besides the order in the json file.

I'm not sure if removing this sort causes different issues, other ideas I had were to prune the tiles that wouldn't be displayed or assign all tiles a new unique order identifier before the sort occurs.