### PR TITLE
allEntities

### DIFF
--- a/include/LDtkLoader/Layer.hpp
+++ b/include/LDtkLoader/Layer.hpp
@@ -45,6 +45,7 @@ namespace ldtk {
 
         auto getIntGridVal(int grid_x, int grid_y) const -> const IntGridValue&;
 
+        auto allEntities() const -> const std::unordered_map<std::string, std::vector<Entity>>&;
         auto hasEntity(const std::string& entity_name) const -> bool;
         auto getEntities(const std::string& entity_name) const -> const std::vector<Entity>&;
 

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -137,6 +137,10 @@ auto Layer::getIntGridVal(int grid_x, int grid_y) const -> const IntGridValue& {
     return IntGridValue::None;
 }
 
+auto Layer::allEntities() const -> const std::unordered_map<std::string, std::vector<Entity>>& {
+    return m_entities;
+}
+
 auto Layer::hasEntity(const std::string& entity_name) const -> bool {
     return m_entities.count(entity_name) > 0;
 }


### PR DESCRIPTION
Here's what I did locally to get around #6 

Possible problem with this method is it sort of makes hasEntity and getEntities redundant.
I thought about adding a different function allEntityNames that would only return the names, but then the whole map has to be iterated through to get that list of keys.

There could be something I'm missing, some other way to know what entities are possible. I'm trying to make a pretty generalized engine right now that can load any ldtk file without knowing much about it.

thx for the binding btw, been a big help for me in creating my engine.