### PR TITLE
Expose Entity __tile Property

### DIFF
--- a/include/LDtkLoader/Entity.hpp
+++ b/include/LDtkLoader/Entity.hpp
@@ -29,9 +29,10 @@ namespace ldtk {
         auto getGridPosition() const -> const IntPoint&;
         auto getColor() const -> const Color&;
         auto getPivot() const -> const FloatPoint&;
+
         auto hasTile() const -> bool;
         auto getTileset() const -> const Tileset&;
-        auto getTilesetRect() const -> const Rect<int>&;
+        auto getTextureRect() const -> const IntRect&;
 
         auto hasIcon() const -> bool;
         auto getIconTileset() const -> const Tileset&;
@@ -50,7 +51,7 @@ namespace ldtk {
         const IntPoint m_grid_pos;
 
         const Tileset* m_tileset = nullptr;
-        Rect<int> m_src_rect;
+        IntRect m_src_rect;
     };
 
 }

--- a/include/LDtkLoader/Entity.hpp
+++ b/include/LDtkLoader/Entity.hpp
@@ -29,6 +29,9 @@ namespace ldtk {
         auto getGridPosition() const -> const IntPoint&;
         auto getColor() const -> const Color&;
         auto getPivot() const -> const FloatPoint&;
+        auto hasTile() const -> bool;
+        auto getTileset() const -> const Tileset&;
+        auto getTilesetRect() const -> const Rect<int>&;
 
         auto hasIcon() const -> bool;
         auto getIconTileset() const -> const Tileset&;
@@ -45,6 +48,9 @@ namespace ldtk {
         const IntPoint m_size;
         const IntPoint m_position;
         const IntPoint m_grid_pos;
+
+        const Tileset* m_tileset = nullptr;
+        Rect<int> m_src_rect;
     };
 
 }

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -11,6 +11,14 @@ m_size( j["width"].get<int>(), j["height"].get<int>() ),
 m_position( j["px"][0].get<int>(), j["px"][1].get<int>() ),
 m_grid_pos( j["__grid"][0].get<int>(), j["__grid"][1].get<int>() )
 {
+    if (j["__tile"] != nullptr)
+    {
+        m_tileset = &w->getTileset(j["__tile"]["tilesetUid"].get<int>());
+        m_src_rect.x = j["__tile"]["srcRect"][0];
+        m_src_rect.y = j["__tile"]["srcRect"][1];
+        m_src_rect.width = j["__tile"]["srcRect"][2];
+        m_src_rect.height = j["__tile"]["srcRect"][3];
+    }
     parseFields(j["fieldInstances"], w);
 }
 
@@ -36,6 +44,18 @@ auto Entity::getColor() const -> const Color& {
 
 auto Entity::getPivot() const -> const FloatPoint& {
     return m_definition->pivot;
+}
+
+auto Entity::hasTile() const -> bool {
+    return m_tileset != nullptr;
+}
+
+auto Entity::getTileset() const -> const Tileset& {
+    return *m_tileset;
+}
+
+auto Entity::getTilesetRect() const -> const Rect<int>& {
+    return m_src_rect;
 }
 
 auto Entity::hasIcon() const -> bool {

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -11,13 +11,12 @@ m_size( j["width"].get<int>(), j["height"].get<int>() ),
 m_position( j["px"][0].get<int>(), j["px"][1].get<int>() ),
 m_grid_pos( j["__grid"][0].get<int>(), j["__grid"][1].get<int>() )
 {
-    if (j["__tile"] != nullptr)
-    {
+    if (!j["__tile"].is_null()) {
         m_tileset = &w->getTileset(j["__tile"]["tilesetUid"].get<int>());
-        m_src_rect.x = j["__tile"]["srcRect"][0];
-        m_src_rect.y = j["__tile"]["srcRect"][1];
-        m_src_rect.width = j["__tile"]["srcRect"][2];
-        m_src_rect.height = j["__tile"]["srcRect"][3];
+        m_src_rect.x = j["__tile"]["srcRect"][0].get<int>();
+        m_src_rect.y = j["__tile"]["srcRect"][1].get<int>();
+        m_src_rect.width = j["__tile"]["srcRect"][2].get<int>();
+        m_src_rect.height = j["__tile"]["srcRect"][3].get<int>();
     }
     parseFields(j["fieldInstances"], w);
 }
@@ -54,7 +53,7 @@ auto Entity::getTileset() const -> const Tileset& {
     return *m_tileset;
 }
 
-auto Entity::getTilesetRect() const -> const Rect<int>& {
+auto Entity::getTextureRect() const -> const IntRect& {
     return m_src_rect;
 }
 


### PR DESCRIPTION
Hello again Madour. I was working some more with Entities in a generalized way, and realized that there can be two tilesets per Entity: one for the 'icon' and another that is the actual sprite for the entity. Sometimes an Entity can only have the icon, sometimes both, and sometimes neither.

The sample entities.ldtk file that comes with the tool is a good example of this, enemies have both an icon and a sprite, chests have only an icon, and doors have neither.

Looking through the json, "__tile" stood out to me as the easiest way to get the sprite tileset and position. If an Entity only has an icon, this property will specify the icon.

Let me know what you think and if there's a better way to do this!