### PR TITLE
Adding support for Layer's OverrideTilesetUid

### DIFF
--- a/include/LDtkLoader/Layer.hpp
+++ b/include/LDtkLoader/Layer.hpp
@@ -57,6 +57,7 @@ namespace ldtk {
         void updateTileVerticesCol(const Tile& tile) const;
 
         const LayerDef* m_definition = nullptr;
+        const Tileset* m_overrideTileset = nullptr;
 
         bool m_visible;
         mutable IntPoint m_total_offset;

--- a/include/LDtkLoader/Layer.hpp
+++ b/include/LDtkLoader/Layer.hpp
@@ -57,7 +57,7 @@ namespace ldtk {
         void updateTileVerticesCol(const Tile& tile) const;
 
         const LayerDef* m_definition = nullptr;
-        const Tileset* m_overrideTileset = nullptr;
+        const Tileset* m_override_tileset = nullptr;
 
         bool m_visible;
         mutable IntPoint m_total_offset;

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -15,6 +15,12 @@ m_total_offset(j["__pxTotalOffsetX"].get<int>(), j["__pxTotalOffsetY"].get<int>(
 m_opacity(j["__opacity"].get<float>()),
 m_grid_size({j["__cWid"].get<int>(), j["__cHei"].get<int>()})
 {
+	auto& overrideTilesetUid = j["overrideTilesetUid"];
+	if (!overrideTilesetUid.is_null())
+	{
+		m_overrideTileset = &w->getTileset(overrideTilesetUid.get<int>());
+	}
+
     std::string key = "gridTiles";
     int coordId_index = 0;
     if (getType() == LayerType::IntGrid || getType() == LayerType::AutoLayer) {
@@ -112,11 +118,11 @@ void Layer::setOpacity(float opacity) const {
 }
 
 auto Layer::hasTileset() const -> bool {
-    return m_definition->m_tileset != nullptr;
+	return m_overrideTileset != nullptr || m_definition->m_tileset != nullptr;
 }
 
 auto Layer::getTileset() const -> const Tileset& {
-    return *m_definition->m_tileset;
+	return m_overrideTileset == nullptr ? *m_definition->m_tileset : *m_overrideTileset;
 }
 
 auto Layer::allTiles() const -> const std::vector<Tile>& {

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -15,10 +15,8 @@ m_total_offset(j["__pxTotalOffsetX"].get<int>(), j["__pxTotalOffsetY"].get<int>(
 m_opacity(j["__opacity"].get<float>()),
 m_grid_size({j["__cWid"].get<int>(), j["__cHei"].get<int>()})
 {
-    auto& overrideTilesetUid = j["overrideTilesetUid"];
-    if (!overrideTilesetUid.is_null())
-    {
-        m_overrideTileset = &w->getTileset(overrideTilesetUid.get<int>());
+    if ( !j["overrideTilesetUid"].is_null() ) {
+        m_override_tileset = &w->getTileset(j["overrideTilesetUid"].get<int>());
     }
 
     std::string key = "gridTiles";
@@ -118,11 +116,11 @@ void Layer::setOpacity(float opacity) const {
 }
 
 auto Layer::hasTileset() const -> bool {
-    return m_overrideTileset != nullptr || m_definition->m_tileset != nullptr;
+    return m_override_tileset != nullptr || m_definition->m_tileset != nullptr;
 }
 
 auto Layer::getTileset() const -> const Tileset& {
-    return m_overrideTileset == nullptr ? *m_definition->m_tileset : *m_overrideTileset;
+    return m_override_tileset == nullptr ? *m_definition->m_tileset : *m_override_tileset;
 }
 
 auto Layer::allTiles() const -> const std::vector<Tile>& {

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -15,11 +15,11 @@ m_total_offset(j["__pxTotalOffsetX"].get<int>(), j["__pxTotalOffsetY"].get<int>(
 m_opacity(j["__opacity"].get<float>()),
 m_grid_size({j["__cWid"].get<int>(), j["__cHei"].get<int>()})
 {
-	auto& overrideTilesetUid = j["overrideTilesetUid"];
-	if (!overrideTilesetUid.is_null())
-	{
-		m_overrideTileset = &w->getTileset(overrideTilesetUid.get<int>());
-	}
+    auto& overrideTilesetUid = j["overrideTilesetUid"];
+    if (!overrideTilesetUid.is_null())
+    {
+        m_overrideTileset = &w->getTileset(overrideTilesetUid.get<int>());
+    }
 
     std::string key = "gridTiles";
     int coordId_index = 0;
@@ -118,11 +118,11 @@ void Layer::setOpacity(float opacity) const {
 }
 
 auto Layer::hasTileset() const -> bool {
-	return m_overrideTileset != nullptr || m_definition->m_tileset != nullptr;
+    return m_overrideTileset != nullptr || m_definition->m_tileset != nullptr;
 }
 
 auto Layer::getTileset() const -> const Tileset& {
-	return m_overrideTileset == nullptr ? *m_definition->m_tileset : *m_overrideTileset;
+    return m_overrideTileset == nullptr ? *m_definition->m_tileset : *m_overrideTileset;
 }
 
 auto Layer::allTiles() const -> const std::vector<Tile>& {


### PR DESCRIPTION
LDtk supports "override tilesets" for "Tiles" layers.
This is done by choosing a different tileset than the default one from the dropdown.

![image](https://user-images.githubusercontent.com/20295773/151680242-89b6d4b5-4e02-46dd-9c4b-90e757786045.png)

This PR adds support for detecting and providing the correct tileset - whether it was overridden from default or not.
