### PR TITLE
json: move json.hpp to src and add public json_fwd.hpp

### DIFF
--- a/include/LDtkLoader/Entity.hpp
+++ b/include/LDtkLoader/Entity.hpp
@@ -6,7 +6,7 @@
 #include <memory>
 #include <iostream>
 #include <unordered_map>
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/containers/FieldsContainer.hpp"
 #include "LDtkLoader/defs/EntityDef.hpp"
 #include "LDtkLoader/defs/FieldDef.hpp"

--- a/include/LDtkLoader/Enum.hpp
+++ b/include/LDtkLoader/Enum.hpp
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
-#include "LDtkLoader/thirdparty/json.hpp"
+
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/containers/TagsContainer.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 

--- a/include/LDtkLoader/Layer.hpp
+++ b/include/LDtkLoader/Layer.hpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/defs/LayerDef.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 #include "LDtkLoader/Tile.hpp"

--- a/include/LDtkLoader/Level.hpp
+++ b/include/LDtkLoader/Level.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include <map>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/containers/FieldsContainer.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 #include "LDtkLoader/Layer.hpp"

--- a/include/LDtkLoader/Project.hpp
+++ b/include/LDtkLoader/Project.hpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "LDtkLoader/thirdparty/json.hpp"
 #include "LDtkLoader/defs/EntityDef.hpp"
 #include "LDtkLoader/defs/LayerDef.hpp"
 #include "LDtkLoader/DataTypes.hpp"

--- a/include/LDtkLoader/Tile.hpp
+++ b/include/LDtkLoader/Tile.hpp
@@ -4,7 +4,7 @@
 
 #include <array>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 
 namespace ldtk {

--- a/include/LDtkLoader/Tileset.hpp
+++ b/include/LDtkLoader/Tileset.hpp
@@ -6,7 +6,7 @@
 #include <unordered_map>
 
 #include "LDtkLoader/thirdparty/optional.hpp"
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 #include "LDtkLoader/Enum.hpp"
 #include "LDtkLoader/containers/TagsContainer.hpp"

--- a/include/LDtkLoader/World.hpp
+++ b/include/LDtkLoader/World.hpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 
 #include "LDtkLoader/defs/LayerDef.hpp"
 #include "LDtkLoader/defs/EntityDef.hpp"

--- a/include/LDtkLoader/containers/FieldsContainer.hpp
+++ b/include/LDtkLoader/containers/FieldsContainer.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include <unordered_map>
 #include "LDtkLoader/thirdparty/optional.hpp"
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/defs/FieldDef.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 #include "LDtkLoader/Field.hpp"

--- a/include/LDtkLoader/containers/TagsContainer.hpp
+++ b/include/LDtkLoader/containers/TagsContainer.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 
 namespace ldtk {
     class TagsContainer {

--- a/include/LDtkLoader/defs/EntityDef.hpp
+++ b/include/LDtkLoader/defs/EntityDef.hpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/containers/TagsContainer.hpp"
 #include "LDtkLoader/defs/FieldDef.hpp"
 #include "LDtkLoader/DataTypes.hpp"

--- a/include/LDtkLoader/defs/FieldDef.hpp
+++ b/include/LDtkLoader/defs/FieldDef.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 #include "LDtkLoader/Tileset.hpp"
 

--- a/include/LDtkLoader/defs/LayerDef.hpp
+++ b/include/LDtkLoader/defs/LayerDef.hpp
@@ -5,7 +5,7 @@
 #include <map>
 #include <string>
 
-#include "LDtkLoader/thirdparty/json.hpp"
+#include "LDtkLoader/thirdparty/json_fwd.hpp"
 #include "LDtkLoader/DataTypes.hpp"
 #include "LDtkLoader/Tileset.hpp"
 

--- a/include/LDtkLoader/thirdparty/json_fwd.hpp
+++ b/include/LDtkLoader/thirdparty/json_fwd.hpp
@@ -1,0 +1,78 @@
+#ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
+
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+namespace nlohmann
+{
+/*!
+@brief default JSONSerializer template argument
+
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+    template<typename T = void, typename SFINAE = void>
+    struct adl_serializer;
+
+    template<template<typename U, typename V, typename... Args> class ObjectType =
+    std::map,
+            template<typename U, typename... Args> class ArrayType = std::vector,
+            class StringType = std::string, class BooleanType = bool,
+            class NumberIntegerType = std::int64_t,
+            class NumberUnsignedType = std::uint64_t,
+            class NumberFloatType = double,
+            template<typename U> class AllocatorType = std::allocator,
+            template<typename T, typename SFINAE = void> class JSONSerializer =
+            adl_serializer,
+            class BinaryType = std::vector<std::uint8_t>>
+    class basic_json;
+
+/*!
+@brief JSON Pointer
+
+A JSON pointer defines a string syntax for identifying a specific value
+within a JSON document. It can be used with functions `at` and
+`operator[]`. Furthermore, JSON pointers are the base for JSON patches.
+
+@sa [RFC 6901](https://tools.ietf.org/html/rfc6901)
+
+@since version 2.0.0
+*/
+    template<typename BasicJsonType>
+    class json_pointer;
+
+/*!
+@brief default JSON class
+
+This type is the default specialization of the @ref basic_json class which
+uses the standard template types.
+
+@since version 1.0.0
+*/
+    using json = basic_json<>;
+
+    template<class Key, class T, class IgnoredLess, class Allocator>
+    struct ordered_map;
+
+/*!
+@brief ordered JSON class
+
+This type preserves the insertion order of object keys.
+
+@since version 3.9.0
+*/
+    using ordered_json = basic_json<nlohmann::ordered_map>;
+
+}  // namespace nlohmann
+
+#endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -2,6 +2,7 @@
 
 #include "LDtkLoader/Entity.hpp"
 #include "LDtkLoader/World.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/EntityDef.cpp
+++ b/src/EntityDef.cpp
@@ -2,6 +2,7 @@
 
 #include "LDtkLoader/defs/EntityDef.hpp"
 #include "LDtkLoader/Project.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/Enum.cpp
+++ b/src/Enum.cpp
@@ -3,7 +3,7 @@
 #include "LDtkLoader/Enum.hpp"
 #include "LDtkLoader/Tileset.hpp"
 #include "LDtkLoader/Utils.hpp"
-
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/FieldsContainer.cpp
+++ b/src/FieldsContainer.cpp
@@ -2,6 +2,7 @@
 
 #include "LDtkLoader/containers/FieldsContainer.hpp"
 #include "LDtkLoader/World.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -5,6 +5,8 @@
 #include "LDtkLoader/Layer.hpp"
 #include "LDtkLoader/World.hpp"
 
+#include "json.hpp"
+
 using namespace ldtk;
 
 Layer::Layer(const nlohmann::json& j, const World* w, const Level* l) :

--- a/src/LayerDef.cpp
+++ b/src/LayerDef.cpp
@@ -1,9 +1,11 @@
 // Created by Modar Nasser on 12/11/2020.
 
+#include "LDtkLoader/defs/LayerDef.hpp"
+
 #include <iostream>
 
-#include "LDtkLoader/defs/LayerDef.hpp"
 #include "LDtkLoader/Project.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -5,6 +5,7 @@
 
 #include "LDtkLoader/Level.hpp"
 #include "LDtkLoader/World.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 
 #include "LDtkLoader/World.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/TagsContainer.cpp
+++ b/src/TagsContainer.cpp
@@ -2,6 +2,7 @@
 
 #include "LDtkLoader/containers/TagsContainer.hpp"
 
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/Tileset.cpp
+++ b/src/Tileset.cpp
@@ -2,6 +2,7 @@
 
 #include "LDtkLoader/Tileset.hpp"
 #include "LDtkLoader/Project.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -7,6 +7,7 @@
 
 #include "LDtkLoader/Project.hpp"
 #include "LDtkLoader/Utils.hpp"
+#include "json.hpp"
 
 using namespace ldtk;
 

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -3016,7 +3016,8 @@ This type preserves the insertion order of object keys.
     using ordered_json = basic_json<nlohmann::ordered_map>;
 
 }  // namespace nlohmann
-
+#else   // INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#include <LDtkLoader/thirdparty/json_fwd.hpp>
 #endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
 
 


### PR DESCRIPTION
Fix compile time issue by forward declaring json structs in json_fwd.hpp and moving the json.hpp to src.

Users will now only include the json interface in their projects and not the full implementation.

This reduces compile time for 1 compilation unit by approximately 60% :)