### PR TITLE
Fix level uid to level iid

### DIFF
--- a/include/LDtkLoader/Level.hpp
+++ b/include/LDtkLoader/Level.hpp
@@ -55,7 +55,7 @@ namespace ldtk {
     private:
         std::vector<Layer> m_layers;
         std::experimental::optional<BgImage> m_bg_image;
-        std::map<Dir, std::vector<int>> m_neighbours_id;
+        std::map<Dir, std::vector<IID>> m_neighbours_id;
         std::map<Dir, std::vector<const Level*>> m_neighbours;
     };
 

--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -29,7 +29,7 @@ depth(j.contains("worldDepth") ? j["worldDepth"].get<int>() : 0)
     m_neighbours_id[Dir::South]; m_neighbours_id[Dir::West];
     for (const auto& neighbour : j["__neighbours"]) {
         const auto& dir = neighbour["dir"].get<std::string>();
-        const auto& level_uid = neighbour["levelUid"].get<int>();
+        const auto& level_uid = IID(neighbour["levelIid"].get<std::string>());
         if (dir == "n")
             m_neighbours_id[Dir::North].push_back(level_uid);
         else if (dir == "e")
@@ -85,7 +85,7 @@ auto Level::getNeighbours(const Dir& direction) const -> const std::vector<const
 auto Level::getNeighbourDirection(const Level& level) const -> Dir {
     for (const auto& item : m_neighbours_id) {
         for (auto id : item.second) {
-            if (id == level.uid)
+            if (id == level.iid)
                 return item.first;
         }
     }


### PR DESCRIPTION
The `levelUid` field has been removed in LDtk 1.2.0. This patch fixes the parser by using `LevelIid` instead.