### PR TITLE
Add LDTK_FIELD_PUBLIC_OPTIONAL CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ option(LDTK_BUILD_SDL_EXAMPLE    "Build an example using LDtkLoader with SDL."  
 option(LDTK_BUILD_RAYLIB_EXAMPLE "Build an example using LDtkLoader with raylib." OFF)
 option(LDTK_BUILD_API_TEST       "Build an example that loads a file showcasing all features of LDtk."  OFF)
 
+option(LDTK_FIELD_PUBLIC_OPTIONAL "Set to ON to enable the full optional interface on Field structures" OFF)
+mark_as_advanced(LDTK_FIELD_PUBLIC_OPTIONAL)
+
 if (LDTK_NO_THROW)
     target_compile_definitions(LDtkLoader PUBLIC LDTK_NO_THROW)
 endif()
@@ -50,6 +53,10 @@ endif()
 if (LDTK_BUILD_API_TEST)
     message(STATUS "LDtkAPI_test target available.")
     add_subdirectory(examples/API_test)
+endif()
+
+if (LDTK_FIELD_PUBLIC_OPTIONAL)
+    target_compile_definitions(LDtkLoader PUBLIC LDTK_FIELD_PUBLIC_OPTIONAL)
 endif()
 
 # cmake install rules

--- a/include/LDtkLoader/Field.hpp
+++ b/include/LDtkLoader/Field.hpp
@@ -24,7 +24,11 @@ namespace ldtk {
     struct ArrayField;
 
     template <typename T>
+#if defined LDTK_FIELD_PUBLIC_OPTIONAL
+    struct Field : IField, public optional<T> {
+#else
     struct Field : IField, private optional<T> {
+#endif
     private:
         static ArrayField<T> m_dummy;
     public:
@@ -33,7 +37,6 @@ namespace ldtk {
         using optional<T>::optional;
         using optional<T>::value;
         using optional<T>::value_or;
-        using optional<T>::operator->;
 
         constexpr auto is_null() const -> bool {
             return !optional<T>::has_value();


### PR DESCRIPTION
When enabled, ldtk::Field will inherit publicly from optional.
This switch gives advanced users a way to use the standard optional interface from a Field object. 
Might be removed from future version of LDtkLoader, use with caution.

(@jpvanoosten 's request from #26)
