### PR TITLE
Add support for individual tile offsets

### DIFF
--- a/include/LDtkLoader/Tile.hpp
+++ b/include/LDtkLoader/Tile.hpp
@@ -23,6 +23,8 @@ namespace ldtk {
 
         const float alpha;
 
+        const IntPoint offset;
+
         auto getPosition() const -> IntPoint;
         auto getGridPosition() const -> IntPoint;
         auto getWorldPosition() const -> IntPoint;

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -140,6 +140,6 @@ auto Layer::getEntity(const IID& entity_iid) const -> const Entity& {
 }
 
 auto Layer::getCoordIdAt(int x, int y) const -> int {
-    return (x + y * m_grid_size.x) / getCellSize() ;
+    return (x / getCellSize()) + (y / getCellSize()) * m_grid_size.x;
 }
 

--- a/src/Tile.cpp
+++ b/src/Tile.cpp
@@ -14,14 +14,15 @@ coordId(l == nullptr ? -1 : l->getCoordIdAt(pos.x, pos.y)),
 tileId(tile_id),
 flipX(flips & 1),
 flipY((flips>>1) & 1),
-alpha(a)
+alpha(a),
+offset(l == nullptr ? -1 : pos.x - (pos.x / l->getCellSize()) * l->getCellSize(), l == nullptr ? -1 : pos.y - (pos.y / l->getCellSize()) * l->getCellSize())
 {}
 
 auto Tile::getPosition() const -> IntPoint {
     auto cell_size = layer->getCellSize();
     auto grid_pos = getGridPosition();
-    auto offset = layer->getOffset();
-    return {grid_pos.x * cell_size + offset.x, grid_pos.y * cell_size + offset.y};
+    auto layer_offset = layer->getOffset();
+    return {grid_pos.x * cell_size + layer_offset.x + offset.x, grid_pos.y * cell_size + layer_offset.y + offset.y};
 }
 
 auto Tile::getGridPosition() const -> IntPoint {


### PR DESCRIPTION
new field `Tile::offset` to represent the offset of the tile's position in pixels.
also the `Layer::getCoordAt` function gave wrong results when the position wasn't the exact coordinate of the grid, so that's fixed as well.